### PR TITLE
Added common auth

### DIFF
--- a/templates/openvpn.pam.j2
+++ b/templates/openvpn.pam.j2
@@ -5,6 +5,6 @@
 auth		required	pam_pwdfile.so pwdfile={{openvpn_etcdir}}/users
 account		required	pam_permit.so
 {% else %}
-auth    required        pam_unix.so    shadow    nodelay
-account required        pam_unix.so
+@include common-auth
+@include common-account
 {% endif %}


### PR DESCRIPTION
Instead of hardcoding these values, we use common-auth and common-account so that any IdM integration is taken into consideration.